### PR TITLE
Unseal Publicized Types

### DIFF
--- a/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
+++ b/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
@@ -59,7 +59,7 @@ public static class AssemblyPublicizer
         if (!options.PublicizeCompilerGenerated && typeDefinition.IsCompilerGenerated())
             return;
 
-        if (options.HasTarget(PublicizeTarget.Types) && (!typeDefinition.IsNested && !typeDefinition.IsPublic || typeDefinition.IsNested && !typeDefinition.IsNestedPublic))
+        if (options.HasTarget(PublicizeTarget.Types) && (!typeDefinition.IsNested && !typeDefinition.IsPublic || typeDefinition.IsNested && !typeDefinition.IsNestedPublic || typeDefinition.IsSealed))
         {
             if (attribute != null)
                 typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & TypeAttributes.VisibilityMask));

--- a/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
+++ b/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
@@ -62,7 +62,7 @@ public static class AssemblyPublicizer
         if (options.HasTarget(PublicizeTarget.Types) && (!typeDefinition.IsNested && !typeDefinition.IsPublic || typeDefinition.IsNested && !typeDefinition.IsNestedPublic || typeDefinition.IsSealed))
         {
             if (attribute != null)
-                typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & TypeAttributes.VisibilityMask));
+                typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & TypeAttributes.VisibilityMask & TypeAttributes.Sealed));
 
             typeDefinition.Attributes &= ~TypeAttributes.VisibilityMask;
             typeDefinition.Attributes &= ~TypeAttributes.Sealed;

--- a/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
+++ b/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
@@ -65,6 +65,7 @@ public static class AssemblyPublicizer
                 typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & TypeAttributes.VisibilityMask));
 
             typeDefinition.Attributes &= ~TypeAttributes.VisibilityMask;
+            typeDefinition.Attributes &= ~TypeAttributes.Sealed;
             typeDefinition.Attributes |= typeDefinition.IsNested ? TypeAttributes.NestedPublic : TypeAttributes.Public;
         }
 

--- a/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
+++ b/BepInEx.AssemblyPublicizer/AssemblyPublicizer.cs
@@ -62,7 +62,7 @@ public static class AssemblyPublicizer
         if (options.HasTarget(PublicizeTarget.Types) && (!typeDefinition.IsNested && !typeDefinition.IsPublic || typeDefinition.IsNested && !typeDefinition.IsNestedPublic || typeDefinition.IsSealed))
         {
             if (attribute != null)
-                typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & TypeAttributes.VisibilityMask & TypeAttributes.Sealed));
+                typeDefinition.CustomAttributes.Add(attribute.ToCustomAttribute(typeDefinition.Attributes & (TypeAttributes.VisibilityMask | TypeAttributes.Sealed)));
 
             typeDefinition.Attributes &= ~TypeAttributes.VisibilityMask;
             typeDefinition.Attributes &= ~TypeAttributes.Sealed;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NuGet](https://img.shields.io/nuget/v/BepInEx.AssemblyPublicizer.MSBuild?label=BepInEx.AssemblyPublicizer.MSBuild&logo=NuGet)](https://www.nuget.org/packages/BepInEx.AssemblyPublicizer.MSBuild)
 [![NuGet](https://img.shields.io/nuget/v/BepInEx.AssemblyPublicizer.Cli?label=BepInEx.AssemblyPublicizer.Cli&logo=NuGet)](https://www.nuget.org/packages/BepInEx.AssemblyPublicizer.Cli)
 
-Yet another assembly publicizer/stripper
+Yet another assembly publicizer/stripper/unsealer
 
 ## Using
 


### PR DESCRIPTION
## Why?

- Runtime allows it.
- Can ease implementation of types that may closely mimic an existing type that the original developer, though counter-productive to our goals, didn't intend to be inherited.
- Sets this Publicizer apart from others so it's not "Just another assembly publicizer" but instead a uniquely valuable resource!

✅  Verified unsealed classes are inheritable with the original dll present in the runtime.